### PR TITLE
Fix final conclusion extraction

### DIFF
--- a/utils/Evidence_Retrieval/pubmedretrieval.py
+++ b/utils/Evidence_Retrieval/pubmedretrieval.py
@@ -162,7 +162,13 @@ class PubMedRetrieval:
             tag='final conclusion', msg_content=response.msgs[0].content
         )
 
-        return True if final_conclusion[-1].lower() == 'yes' else False
+        if not final_conclusion:
+            logging.warning(
+                "No <final conclusion> tag found when judging valid component"
+            )
+            return False
+
+        return final_conclusion[-1].strip().lower() == 'yes'
 
     def get_search_terms(self, valid_components: dict) -> dict:
         professional_medical_librarian_msg_content = (


### PR DESCRIPTION
## Summary
- avoid crashing when PubMedRetrieval doesn't return `<final conclusion>` tag

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68403dbc8fcc8330b90fe2a571cf855d